### PR TITLE
Get things to compile on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,9 @@ target_include_directories(stlab INTERFACE ${STLAB_INCLUDE_DIRS})
 
 add_library(stlab-extras INTERFACE)
 target_include_directories(stlab-extras INTERFACE ${CMAKE_SOURCE_DIR}/include/)
+target_include_directories(stlab-extras INTERFACE ${Boost_INCLUDE_DIRS})
 target_link_libraries(stlab-extras INTERFACE stlab)
-target_link_libraries(stlab-extras INTERFACE Boost::system)
+target_link_libraries(stlab-extras INTERFACE ${Boost_LIBRARIES})
 target_link_libraries(stlab-extras INTERFACE Threads::Threads)
 
 add_subdirectory(examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(boostcoro2 boostcoro2.cpp)
-target_link_libraries(boostcoro2 PUBLIC stlab-extras Boost::coroutine)
+target_link_libraries(boostcoro2 PUBLIC stlab-extras)
 
 add_executable(observable observable.cpp)
 target_link_libraries(observable PUBLIC stlab-extras)

--- a/include/stlab-extras/observable.hpp
+++ b/include/stlab-extras/observable.hpp
@@ -43,12 +43,14 @@ template <> struct void_helper<void> {
 };
 template <typename T> class subscriber {
 public:
+  virtual ~subscriber() = default;
   virtual void on_value(T value) = 0;
   virtual void on_end(std::exception_ptr) = 0;
 };
 
 template <> class subscriber<void> {
 public:
+  virtual ~subscriber() = default;
   virtual void on_value() = 0;
   virtual void on_end(std::exception_ptr) = 0;
 };
@@ -101,7 +103,7 @@ public:
   // What dependencies to keep alive.
   std::list<std::shared_ptr<void>> dependencies_;
 
-  struct observable_subscription;
+  class observable_subscription;
   typedef std::list<std::weak_ptr<observable_subscription>>
       subscription_list_type;
   subscription_list_type subscriptions_;
@@ -286,6 +288,7 @@ private:
   std::weak_ptr<shared_observable<O>> weak_output_;
 
 public:
+  ~transforming_subscriber() override = default;
   void on_value(I input) override {
     if (auto output = weak_output_.lock()) {
       output->executor_([
@@ -330,6 +333,7 @@ private:
   std::weak_ptr<shared_observable<O>> weak_output_;
 
 public:
+  ~transforming_subscriber() override = default;
   void on_value() override {
     if (auto output = weak_output_.lock()) {
       output->executor_([_this(this->shared_from_this())]() mutable {


### PR DESCRIPTION
These changes allow me to run the examples.

I have boost 1.66 and cmake 3.10. Unfortunately the abstract targets `boost::system` etc need to be manually maintained by cmake. By using Boost_LIBRARIES we don't have this problem.

Also fixed a wrong forward declaration (struct --> class)

Also fixed a strange error on clang where it complained about a non-virtual destructor.